### PR TITLE
Update: finer timestamps in logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ test/googletest
 
 # Settings.json file (for now /Sonja)
 .vscode/settings.json
+
+webserv
+siege.[0-9]*

--- a/include/Log.hpp
+++ b/include/Log.hpp
@@ -8,7 +8,7 @@
 #define INFO_LOGGING	1
 #define DEBUG_LOGGING	1
 
-#define TIMESTAMP_WIDTH	23
+#define TIMESTAMP_WIDTH	27
 #define CATEGORY_WIDTH	20
 
 enum class LogType {

--- a/srcs/Log.cpp
+++ b/srcs/Log.cpp
@@ -27,10 +27,19 @@ void	Log::logTime(std::ostream *outputStream)
 	auto	timePoint	= std::chrono::system_clock::now();
 	auto	time		= std::chrono::system_clock::to_time_t(timePoint);
 
+	auto	sinceEpoch	= timePoint.time_since_epoch();
+	auto	ms			= sinceEpoch.count() % 1000000000 / 1000000;	// Milliseconds
+	auto	us			= sinceEpoch.count() % 1000000 / 1000;			// Microseconds
+	auto	ns			= sinceEpoch.count() % 1000;					// Nanoseconds
+
 	std::stringstream	timeStream;
 	std::string			timeStr;
 
-	timeStream	<< std::put_time(std::localtime(&time), "%F %T");
+	timeStream.imbue(std::locale::classic());
+	timeStream	<< std::put_time(std::localtime(&time), "%F %T.");
+	timeStream << std::setw(3) << std::setfill('0') << ms << ",";
+	timeStream << std::setw(3) << std::setfill('0') << us << ",";
+	timeStream << std::setw(3) << std::setfill('0') << ns;
 	timeStr		= timeStream.str();
 
 	*outputStream << std::setw(TIMESTAMP_WIDTH) << std::left << timeStr;


### PR DESCRIPTION
To make timestamps more explicit and useful for observing changes in the milli, micro, and nanosecond range I made the timestamps include that information, seconds aren't nearly enough for most operations of our server. We can scale this back/make the precision a compilation option later.