### PR TITLE
Handling only one request per recv buffer, storing _boundary in Request for content-type: multipart/form-data

### DIFF
--- a/docs/netcat_testing.md
+++ b/docs/netcat_testing.md
@@ -2,7 +2,7 @@
 
 ## Most simple example
 ```
-echo "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n" | nc localhost 8081
+echo -n "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n" | nc localhost 8081
 ```
 
 There are example files in `tests/requests` that can be read with `cat` and

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -52,20 +52,21 @@ class Request
 	using timePoint = std::chrono::time_point<std::chrono::high_resolution_clock>;
 
 	private:
-		int						_fd;
-		int						_serverFd;
-		std::string				_buffer;
-		struct RequestLine		_request;
-		stringMap				_headers;
-		std::string				_body;
-		std::optional<size_t>	_contentLen;
-		bool					_keepAlive;
-		bool					_chunked;
-		bool					_completeHeaders;
-		RequestStatus			_status;
-		timePoint				_idleStart;
-		timePoint				_recvStart;
-		timePoint				_sendStart;
+		int							_fd;
+		int							_serverFd;
+		std::string					_buffer;
+		struct RequestLine			_request;
+		stringMap					_headers;
+		std::string					_body;
+		std::optional<size_t>		_contentLen;
+		std::optional<std::string>	_boundary;
+		bool						_keepAlive;
+		bool						_chunked;
+		bool						_completeHeaders;
+		RequestStatus				_status;
+		timePoint					_idleStart;
+		timePoint					_recvStart;
+		timePoint					_sendStart;
 
 	public:
 		Request() = delete;
@@ -94,6 +95,7 @@ class Request
 		void				setRecvStart(void);
 		void				setSendStart(void);
 		void				resetSendStart(void);
+		void				resetBuffer(void);
 
 		RequestMethod						getRequestMethod(void) const;
 		std::string const					&getHttpVersion(void) const;

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -265,19 +265,34 @@ void	Request::parseHeaders(std::string& str) {
 		for (size_t i = 0; i < key.size(); i++)
 			key[i] = std::tolower(static_cast<unsigned char>(key[i]));
 		std::string value = line.substr(point + 2, line.size() - (point + 2));
-		for (size_t i = 0; i < value.size(); i++)
-			value[i] = std::tolower(static_cast<unsigned char>(value[i]));
+		if (key != "content-type") {
+			for (size_t i = 0; i < value.size(); i++)
+				value[i] = std::tolower(static_cast<unsigned char>(value[i]));
+		}
 		if (isNeededHeader(key)) {
-			if (value.find(",") == std::string::npos) {
-				_headers[key].emplace_back(value);
-				continue;
-			}
 			std::istringstream	values(value);
 			std::string	oneValue;
-			while (getline(values, oneValue, ',')) {
-				if (oneValue[0] == ' ')
-					oneValue = oneValue.substr(1);
-				_headers[key].emplace_back(oneValue);
+			if (key == "content-type") {
+				if (value.find(";") == std::string::npos) {
+					_headers[key].emplace_back(value);
+					continue;
+				}
+				while (getline(values, oneValue, ';')) {
+					if (oneValue[0] == ' ')
+						oneValue = oneValue.substr(1);
+					_headers[key].emplace_back(oneValue);
+				}
+			}
+			else {
+				if (value.find(",") == std::string::npos) {
+					_headers[key].emplace_back(value);
+					continue;
+				}
+				while (getline(values, oneValue, ',')) {
+					if (oneValue[0] == ' ')
+						oneValue = oneValue.substr(1);
+					_headers[key].emplace_back(oneValue);
+				}
 			}
 		}
 	}
@@ -419,6 +434,20 @@ bool	Request::validateHeaders(void) {
 			return false;
 		_chunked = true;
 	}
+	it = _headers.find("content-type");
+	if (it != _headers.end()) {
+		if (std::find(it->second.begin(), it->second.end(), "multipart/form-data") != it->second.end()) {
+			auto	value = it->second.begin();
+			for (value = it->second.begin(); value != it->second.end(); value++) {
+				if (value->substr(0, 9) == "boundary=") {
+					_boundary = value->substr(9);
+					break ;
+				}
+			}
+			if (value == it->second.end())
+				return false;
+		}
+	}
 	return true;
 }
 
@@ -540,35 +569,41 @@ static void	printStatus(RequestStatus status)
  * Prints parsed data for debugging.
  */
 void	Request::printData(void) const {
-	std::cout << "\n---- Request line ----\nMethod: ";
+	std::cout << "---- Request line ----\nMethod: ";
 	switch(_request.method) {
 		case RequestMethod::Get:
-			std::cout << "GET";
+			std::cout << "Get";
 			break ;
 		case RequestMethod::Post:
-			std::cout << "POST";
+			std::cout << "Post";
 			break ;
 		case RequestMethod::Delete:
-			std::cout << "DELETE";
+			std::cout << "Delete";
 			break ;
 		default:
 			throw std::runtime_error("HTTP request method unknown\n");
 	}
-	std::cout << "\nTarget: " << _request.target << "\nHTTP version: " << _request.httpVersion << "\n";
+	std::cout << ", target: "
+		<< _request.target << ", HTTP version: " << _request.httpVersion << "\n\n";
 	if (_request.query.has_value())
 		std::cout << "Query: " << _request.query.value() << '\n';
-	std::cout << "----------------------\n\n";
-	std::cout << "---- Header keys ----\n";
-	for (auto it = _headers.begin(); it != _headers.end(); it++)
-		std::cout << it->first << '\n';
-	std::cout << "---------------------\n\n";
+	std::cout << "---- Headers ----\n";
+	for (auto it = _headers.begin(); it != _headers.end(); it++) {
+		std::cout << it->first << ": ";
+		for (auto value = it->second.begin(); value != it->second.end(); value++)
+			std::cout << *value << " ";
+		std::cout << '\n';
+	}
+	std::cout << "\n";
 	if (!_body.empty())
-		std::cout << "---- Body ----\n" << _body << "----------------\n\n";
+		std::cout << "---- Body ----\n" << _body << '\n';
 	std::cout << "	Keep alive?		" << _keepAlive << '\n';
 	std::cout << "	Complete headers?	" << _completeHeaders << '\n';
 	std::cout << "	Status?			";
 	printStatus(_status);
-	std::cout << "	Chunked?		" << _chunked << "\n\n";
+	std::cout << "	Chunked?		" << _chunked << "\n";
+	if (_boundary.has_value())
+		std::cout << "	Boundary:		'" << _boundary.value() << "'\n\n";
 }
 
 void	Request::setIdleStart(void) {
@@ -588,6 +623,14 @@ void	Request::setSendStart(void) {
 
 void	Request::resetSendStart(void) {
 	_sendStart = {};
+}
+
+void	Request::resetBuffer(void) {
+	if (!_buffer.empty()) {
+		std::cout << "BUFFER IS: '" << _buffer << "'\n";
+		INFO_LOG("The remaining request data in buffer following one compele request will be discarded");
+		_buffer.clear();
+	}
 }
 
 std::string	Request::getHost(void) const {

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -237,7 +237,7 @@ void	Server::handleClientData(size_t& i)
 
 	buf[numBytes] = '\0';
 	INFO_LOG("Received client data from fd " + std::to_string(_pfds[i].fd));
-	std::cout << "\n---- Request data ----\n" << buf << "----------------------\n\n";
+	std::cout << "\n---- Request data ----\n" << buf << '\n';
 
 	if (!_clients.empty())
 	{
@@ -251,43 +251,39 @@ void	Server::handleClientData(size_t& i)
 		it->setRecvStart();
 		it->saveRequest(std::string(buf));
 
-		while (!(it->getBuffer().empty()))
+		it->handleRequest();
+
+		if (it->getStatus() == RequestStatus::Error)
 		{
-			it->handleRequest();
+			ERROR_LOG("Client fd " + std::to_string(_pfds[i].fd)
+				+ " connection dropped: suspicious request");
 
-			if (it->getStatus() == RequestStatus::Error)
-			{
-				ERROR_LOG("Client fd " + std::to_string(_pfds[i].fd)
-					+ " connection dropped: suspicious request");
+			removeClientFromPollFds(i);
 
-				removeClientFromPollFds(i);
+			INFO_LOG("Erasing fd " + std::to_string(it->getFd()) + " from clients list");
+			_clients.erase(it);
 
-				INFO_LOG("Erasing fd " + std::to_string(it->getFd()) + " from clients list");
-				_clients.erase(it);
-
-				return ;
-			}
-
-			if (it->getStatus() == RequestStatus::WaitingData)
-			{
-				INFO_LOG("Waiting for more data to complete partial request");
-
-				return ;
-			}
-
-			INFO_LOG("Building response to client fd " + std::to_string(_pfds[i].fd));
-
-			Config const	&conf = matchConfig(*it);
-
-			DEBUG_LOG("Matched config: " + conf.host + " " + conf.host_name + " " + std::to_string(conf.ports[0]));
-
-			_responses[_pfds[i].fd].emplace_back(Response(*it, conf));
-			it->reset();
-			it->setStatus(RequestStatus::ReadyForResponse);
-			_pfds[i].events |= POLLOUT;
-			if (!it->getKeepAlive())
-				break;
+			return ;
 		}
+
+		if (it->getStatus() == RequestStatus::WaitingData)
+		{
+			INFO_LOG("Waiting for more data to complete partial request");
+
+			return ;
+		}
+
+		INFO_LOG("Building response to client fd " + std::to_string(_pfds[i].fd));
+
+		Config	 const &conf = matchConfig(*it);
+		DEBUG_LOG("Matched config: " + conf.host + " " + conf.host_name + " " + std::to_string(conf.ports[0]));
+
+		_responses[_pfds[i].fd].emplace_back(Response(*it, conf));
+		it->reset();
+		it->setStatus(RequestStatus::ReadyForResponse);
+		_pfds[i].events |= POLLOUT;
+
+		it->resetBuffer();
 	}
 }
 
@@ -364,22 +360,21 @@ void	Server::sendResponse(size_t& i)
 		&& it->getStatus() != RequestStatus::RecvTimeout)
 		return ;
 
-	for (auto res = _responses.at(_pfds[i].fd).begin(); _responses.at(_pfds[i].fd).size() > 0; res++)
+	auto &res = _responses.at(_pfds[i].fd).front();
+
+	INFO_LOG("Sending response to client fd " + std::to_string(_pfds[i].fd));
+	it->setIdleStart();
+	it->setSendStart();
+	res.sendToClient();
+	if (!res.sendIsComplete())
 	{
-		INFO_LOG("Sending response to client fd " + std::to_string(_pfds[i].fd));
-		it->setIdleStart();
-		it->setSendStart();
-		res->sendToClient();
-		if (!res->sendIsComplete())
-		{
-			INFO_LOG("Response partially sent, waiting for server to complete response sending");
-			return ;
-		}
-
-		_responses.at(_pfds[i].fd).pop_front();
-
-		it->resetSendStart();
+		INFO_LOG("Response partially sent, waiting for server to complete response sending");
+		return ;
 	}
+
+	_responses.at(_pfds[i].fd).pop_front();
+
+	it->resetSendStart();
 
 	_pfds[i].events &= ~POLLOUT;
 
@@ -426,7 +421,9 @@ void	Server::checkTimeouts(void)
 					+ std::to_string(_pfds[i].fd)));
 			it->checkReqTimeouts();
 			if (it->getStatus() == RequestStatus::RecvTimeout) {
-				_responses[_pfds[i].fd].emplace_back(Response(*it, matchConfig(*it)));
+				Config	 const &conf = matchConfig(*it);
+				DEBUG_LOG("Matched config: " + conf.host + " " + conf.host_name + " " + std::to_string(conf.ports[0]));
+				_responses[_pfds[i].fd].emplace_back(Response(*it, conf));
 				sendResponse(i);
 			}
 			if (it->getStatus() == RequestStatus::IdleTimeout


### PR DESCRIPTION
Handles max one complete request per received buffer, discards rest of data by resetting buffer and writing to info_log, sends one response at a time. Parses and stores _boundary if content-type is multipart/form-data.